### PR TITLE
Set Drupal Site Name

### DIFF
--- a/group_vars/local.yml
+++ b/group_vars/local.yml
@@ -142,6 +142,7 @@ drupalvm_config:
   mysql_query_cache_type: 1
   mysql_innodb_buffer_pool_size: 128M
   mysql_innodb_flush_method: O_DIRECT
+  drupal_site_name: Pacifica Site
   drupal_composer_dependencies:
     - '"symfony/event-dispatcher:4.3.11 as 3.4.41"'
     - "drupal/key_auth"


### PR DESCRIPTION
### Description

This sets the Drupal site name to 'Pacifica Site'

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

Fix #16 
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
